### PR TITLE
Fix #14108 - Registration of LDAP users with an identifier in lowercase

### DIFF
--- a/application/core/plugins/AuthLDAP/AuthLDAP.php
+++ b/application/core/plugins/AuthLDAP/AuthLDAP.php
@@ -426,7 +426,7 @@ class AuthLDAP extends LimeSurvey\PluginManager\AuthPluginBase
         /* unsubscribe from beforeHasPermission, else updating event */
         $this->unsubscribe('beforeHasPermission');
         // Here we do the actual authentication
-        $username = $this->getUsername();
+        $username = strotolower($this->getUsername());
         $password = $this->getPassword();
 
         $ldapmode = $this->get('ldapmode');


### PR DESCRIPTION
No correct error message when the connection between the AuthLDAP plugin and LimeSurvey API fails due to the case sensitivity on the connection identifier

Fixed issue # : 14108